### PR TITLE
fix generic profile import problems

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 0.5 - unreleased
 ----------------
 
-
+ - Fix Generic Setup import [amleczko]
 
 0.4 - 2012-02-06
 ----------------

--- a/plone/portlet/viewlet/portlet.py
+++ b/plone/portlet/viewlet/portlet.py
@@ -44,7 +44,7 @@ class Assignment(base.Assignment):
     
     manager_viewlet = None
         
-    def __init__(self, manager_viewlet):
+    def __init__(self, manager_viewlet=None):
         self.manager_viewlet = manager_viewlet
         
     @property


### PR DESCRIPTION
The `Assignment` constructor should accept only keyword arguments, otherwise the `Generic Profile` import will fail.
